### PR TITLE
Real blur behind popups, and retire the OSD corner shader

### DIFF
--- a/bin/tahoe-glass-apply
+++ b/bin/tahoe-glass-apply
@@ -20,13 +20,19 @@ GTK3_CSS="$HOME/.config/gtk-3.0/gtk.css"
 mkdir -p "$HOME/.config/gtk-3.0"
 [ -f "$GTK3_CSS" ] || : > "$GTK3_CSS"
 
+# apply TARGET SNIPPET... — one marked block per target, concatenating every
+# snippet that is actually present. Optional sheets are installed and removed
+# by install.sh rather than switched on here, so a missing one simply drops out
+# and an older $CONF_DIR with only the original sheets keeps working.
 apply() {
-    local target="$1" snippet="$2"
-    [ -f "$target" ]  || { echo "skip (missing target): $target"; return; }
-    [ -f "$snippet" ] || { echo "skip (missing snippet): $snippet"; return; }
-    python3 - "$target" "$snippet" <<'PY'
+    local target="$1"; shift
+    [ -f "$target" ] || { echo "skip (missing target): $target"; return; }
+    local present=() s
+    for s in "$@"; do [ -f "$s" ] && present+=("$s"); done
+    [ ${#present[@]} -gt 0 ] || { echo "skip (no snippets): $target"; return; }
+    python3 - "$target" "${present[@]}" <<'PY'
 import sys, re
-target, snippet = sys.argv[1], sys.argv[2]
+target, snippets = sys.argv[1], sys.argv[2:]
 BEGIN = "/* >>> tahoe-glass BEGIN <<< */"
 END   = "/* >>> tahoe-glass END <<< */"
 
@@ -39,17 +45,21 @@ for name in ("tahoe-glass", "tahoe-tweaks"):
         r"/\* >>> %s BEGIN <<< \*/.*?/\* >>> %s END <<< \*/\n?" % (name, name),
         "", css, flags=re.S,
     )
-block = open(snippet, encoding="utf-8").read().rstrip("\n")
+# Order is the order given: later sheets are overrides and must win on equal
+# specificity, so they are concatenated rather than merged.
+block = "\n\n".join(
+    open(p, encoding="utf-8").read().rstrip("\n") for p in snippets
+)
 open(target, "w", encoding="utf-8").write(
     css.rstrip("\n") + "\n\n" + BEGIN + "\n" + block + "\n" + END + "\n"
 )
-print("applied ->", target)
+print("applied ->", target, "(%d snippet%s)" % (len(snippets), "" if len(snippets) == 1 else "s"))
 PY
 }
 
-apply "$SHELL_CSS"     "$DIR/shell-tweaks.css"
-apply "$GTK4_CSS"      "$DIR/gtk4-tweaks.css"
-apply "$GTK4_DARK_CSS" "$DIR/gtk4-tweaks.css"
+apply "$SHELL_CSS"     "$DIR/shell-tweaks.css" "$DIR/shell-popup-blur.css"
+apply "$GTK4_CSS"      "$DIR/gtk4-tweaks.css"  "$DIR/gtk4-transparency.css"
+apply "$GTK4_DARK_CSS" "$DIR/gtk4-tweaks.css"  "$DIR/gtk4-transparency.css"
 apply "$GTK3_CSS"      "$DIR/gtk3-tweaks.css"
 
 # The User Themes extension reloads on a settings change, not on a file change,

--- a/css/shell-popup-blur.css
+++ b/css/shell-popup-blur.css
@@ -1,0 +1,56 @@
+/* tahoe-glass — popup translucency, for when there is a real blur behind it.
+ *
+ * Appended after shell-tweaks.css, and only installed when Blur My Shell's
+ * popup component is active (--no-popup-blur leaves it out entirely, which is
+ * what makes that flag a true no-op).
+ *
+ * Everything in shell-tweaks.css paints its own fill because, with the
+ * published Blur My Shell, there is nothing behind a menu but the wallpaper —
+ * the alpha *is* the material. With an actual blur under them those same
+ * values read as smoke rather than glass, so each ground steps down. The
+ * ladder is preserved, only shifted:
+ *
+ *   floating surface (menu) ........... 0.42 -> 0.26
+ *   quick settings .................... 0.46 -> 0.30
+ *   arriving banner ................... 0.86 -> 0.52
+ *
+ * Nothing else moves. Radii, hairlines, the control ladder and every accent
+ * rule carry over from shell-tweaks.css untouched, and this file deliberately
+ * sets no border-radius: the shape is already agreed between that sheet and
+ * the *-corner-radius keys in dconf/core.ini, and repeating it here would be a
+ * third place to keep in sync.
+ *
+ * Nothing here fights Blur My Shell. Its popup stylesheet only applies when
+ * override-background is on, and the preset keeps it off.
+ */
+
+.popup-menu-content {
+  background-color: rgba(0, 0, 0, 0.26);
+}
+
+.popup-menu-content.quick-settings,
+.quick-settings {
+  background-color: rgba(0, 0, 0, 0.30);
+}
+
+/* The banner was near-solid because it floats over anything at all — a bright
+ * window, video, a pale wallpaper — and had to stay legible without help.
+ * It now has its own blurred ground, so it can stop carrying that alone.
+ */
+.notification-banner {
+  background-color: rgba(22, 23, 27, 0.52);
+}
+
+/* .message is a light lift *inside* the calendar popup rather than a ground of
+ * its own, so it is left where shell-tweaks.css put it. It rides whatever is
+ * under it, and what is under it just got lighter.
+ */
+
+/* The OSD pill's fill comes from Custom OSD's inline style, not from here —
+ * see [custom-osd] alpha in dconf/core.ini. Only the level bar needs a nudge:
+ * a blurred, moving ground is less predictable than the flat tint it used to
+ * sit on, and the empty half of the bar was the first thing to disappear.
+ */
+.osd-window .level {
+  -barlevel-background-color: rgba(255, 255, 255, 0.22);
+}

--- a/dconf/core.ini
+++ b/dconf/core.ini
@@ -221,8 +221,12 @@ wmax-hbarhint=false
 wmaxbar=true
 
 [blur-my-shell]
-pipelines={'pipeline_default': {'name': <'Default'>, 'effects': <[<{'type': <'native_static_gaussian_blur'>, 'id': <'effect_000000000000'>, 'params': <{'unscaled_radius': <12.0>, 'brightness': <1.0>}>}>, <{'type': <'noise'>, 'id': <'effect_000000000003'>, 'params': <{'noise': <0.0>, 'lightness': <1.0>}>}>]>}, 'pipeline_default_rounded': {'name': <'Default rounded'>, 'effects': <[<{'type': <'native_static_gaussian_blur'>, 'id': <'effect_000000000001'>, 'params': <{'unscaled_radius': <5.0>, 'brightness': <1.0>}>}>, <{'type': <'corner'>, 'id': <'effect_000000000002'>, 'params': <{'radius': <24>, 'corners_top': <true>, 'corners_bottom': <true>}>}>]>}, 'pipeline_82724085199030': {'name': <'panel'>, 'effects': <[<{'type': <'corner'>, 'id': <'effect_000000000004'>, 'params': <{'radius': <50>, 'corners_top': <true>, 'corners_bottom': <true>}>}>, <{'type': <'native_static_gaussian_blur'>, 'id': <'effect_000000000005'>, 'params': <{'unscaled_radius': <12.0>, 'brightness': <1.0>}>}>]>}, 'pipeline_13830698331882': {'name': <'dock'>, 'effects': <[<{'type': <'native_static_gaussian_blur'>, 'id': <'effect_000000000006'>, 'params': <{'unscaled_radius': <12.0>, 'brightness': <1.0>}>}>, <{'type': <'corner'>, 'id': <'effect_000000000007'>, 'params': <{'radius': <26>, 'corners_top': <true>, 'corners_bottom': <true>}>}>]>}, 'pipeline_91827364550123': {'name': <'lock screen'>, 'effects': <[<{'type': <'native_static_gaussian_blur'>, 'id': <'effect_000000000008'>, 'params': <{'unscaled_radius': <30.0>, 'brightness': <0.80000000000000004>}>}>, <{'type': <'noise'>, 'id': <'effect_000000000009'>, 'params': <{'noise': <0.0>, 'lightness': <1.01>}>}>]>}, 'pipeline_47391028465517': {'name': <'windows'>, 'effects': <[<{'type': <'native_static_gaussian_blur'>, 'id': <'effect_000000000010'>, 'params': <{'unscaled_radius': <12.0>, 'brightness': <1.0>}>}>, <{'type': <'corner'>, 'id': <'effect_000000000011'>, 'params': <{'radius': <14>, 'corners_top': <true>, 'corners_bottom': <true>}>}>]>}}
-rounded-blur-found=false
+pipelines={'pipeline_default': {'name': <'Default'>, 'effects': <[<{'type': <'native_static_gaussian_blur'>, 'id': <'effect_000000000000'>, 'params': <{'unscaled_radius': <12.0>, 'brightness': <1.0>}>}>, <{'type': <'noise'>, 'id': <'effect_000000000003'>, 'params': <{'noise': <0.0>, 'lightness': <1.0>}>}>]>}, 'pipeline_default_rounded': {'name': <'Default rounded'>, 'effects': <[<{'type': <'native_static_gaussian_blur'>, 'id': <'effect_000000000001'>, 'params': <{'unscaled_radius': <5.0>, 'brightness': <1.0>}>}>, <{'type': <'corner'>, 'id': <'effect_000000000002'>, 'params': <{'radius': <24>, 'corners_top': <true>, 'corners_bottom': <true>}>}>]>}, 'pipeline_82724085199030': {'name': <'panel'>, 'effects': <[<{'type': <'corner'>, 'id': <'effect_000000000004'>, 'params': <{'radius': <50>, 'corners_top': <true>, 'corners_bottom': <true>}>}>, <{'type': <'native_static_gaussian_blur'>, 'id': <'effect_000000000005'>, 'params': <{'unscaled_radius': <12.0>, 'brightness': <1.0>}>}>]>}, 'pipeline_13830698331882': {'name': <'dock'>, 'effects': <[<{'type': <'native_static_gaussian_blur'>, 'id': <'effect_000000000006'>, 'params': <{'unscaled_radius': <12.0>, 'brightness': <1.0>}>}>, <{'type': <'corner'>, 'id': <'effect_000000000007'>, 'params': <{'radius': <26>, 'corners_top': <true>, 'corners_bottom': <true>}>}>]>}, 'pipeline_91827364550123': {'name': <'lock screen'>, 'effects': <[<{'type': <'native_static_gaussian_blur'>, 'id': <'effect_000000000008'>, 'params': <{'unscaled_radius': <30.0>, 'brightness': <0.80000000000000004>}>}>, <{'type': <'noise'>, 'id': <'effect_000000000009'>, 'params': <{'noise': <0.0>, 'lightness': <1.01>}>}>]>}, 'pipeline_47391028465517': {'name': <'windows'>, 'effects': <[<{'type': <'native_static_gaussian_blur'>, 'id': <'effect_000000000010'>, 'params': <{'unscaled_radius': <12.0>, 'brightness': <1.0>}>}>, <{'type': <'corner'>, 'id': <'effect_000000000011'>, 'params': <{'radius': <14>, 'corners_top': <true>, 'corners_bottom': <true>}>}>]>}, 'pipeline_28461903752846': {'name': <'popups'>, 'effects': <[<{'type': <'native_static_gaussian_blur'>, 'id': <'effect_000000000012'>, 'params': <{'unscaled_radius': <30.0>, 'brightness': <0.59999999999999998>}>}>]>}}
+# rounded-blur-found is deliberately absent. Blur My Shell writes it itself at
+# every enable — true when the gnome-rounded-blur library is importable — and
+# apply_popup_blur reads it to decide whether the popup blur can be dynamic.
+# Listing it here would have dconf load stamp it back to false on every run,
+# moments before that check.
 settings-version=2
 # Blur My Shell repaints only the region Clutter reports as damaged. The blur
 # actor behind a window does not move when the window does, so nothing marks it
@@ -295,6 +299,40 @@ static-blur=true
 style-panel=0
 unblur-in-overview=true
 
+# Menus, quick settings, notifications, dialogs, the alt-tab switcher and the
+# volume/brightness OSD. This is the component the published build (v72) does
+# not have, and the whole reason Blur My Shell is built from git here.
+#
+# static-blur is not set in this file. Rounded corners on a *dynamic* popup
+# blur come from Blur.BlurEffect in the gnome-rounded-blur library; without it
+# the blur still works but the corners come out square. A *static* blur gets
+# its corners from a corner effect Blur My Shell attaches itself, always. So
+# apply_popup_blur picks the mode at install time from rounded-blur-found:
+# library present means dynamic, absent means static. Round either way.
+#
+# override-background is off on purpose. Blur My Shell's own popup stylesheet
+# repaints menus and adds a 24px drop shadow, and that shadow is the one this
+# desktop already removed once in 0dcb16c. css/shell-tweaks.css keeps the
+# material; this section supplies only the blur and the shape behind it.
+#
+# The radii match the CSS exactly: see .popup-menu-content, .quick-settings and
+# .notification-banner in css/shell-tweaks.css. osd-corner-radius is larger
+# than the pill is tall on purpose — the effect clamps to height/2, so any big
+# number gives a capsule, which is what bradius=100.0 asks Custom OSD for.
+[blur-my-shell/popup]
+blur=true
+pipeline='pipeline_28461903752846'
+sigma=30
+brightness=0.59999999999999998
+corner-radius=20
+menu-corner-radius=26
+quick-settings-corner-radius=33
+notification-corner-radius=20
+osd-corner-radius=40
+dialog-corner-radius=20
+override-background=false
+style-popup=2
+
 [blur-my-shell/screenshot]
 blur=true
 pipeline='pipeline_default'
@@ -313,8 +351,16 @@ name='Tahoe-Dark'
 # left alone — those popups have no bar, so hiding the icon too would leave an
 # empty pill.
 #
-# dynamic-blur is what puts the wallpaper blur behind it. It costs nothing at
-# rest: the effect only exists while the popup is on screen.
+# bg-effect is 'none' on purpose, and it is the interesting part. Custom OSD's
+# own dynamic-blur covers the actor's bounding box and knows nothing about
+# border-radius, so the pill sat in a square patch of blur — which is exactly
+# what it looked like on Intel graphics. Blur My Shell's popup component blurs
+# the OSD instead (osd-window is one of its targets) and clips to
+# osd-corner-radius, so the shape comes out right on every GPU without this
+# project maintaining a shader of its own.
+#
+# So all this section paints now is a translucent capsule, and the blur under
+# it comes from [blur-my-shell/popup].
 [custom-osd]
 osd-all={'icon-all': false, 'label-all': false, 'level-all': true, 'numeric-all': false}
 osd-nolabel={'icon-nolabel': false, 'level-nolabel': true, 'numeric-nolabel': false}
@@ -323,9 +369,11 @@ icon=false
 label=false
 level=true
 numeric=false
-bg-effect='dynamic-blur'
+bg-effect='none'
 bgcolor=['0.11', '0.11', '0.12', '1.0']
-alpha=45.0
+# Lower than it was: 45 was tuned against an unblurred wallpaper, and over a
+# real blur that much tint reads as a slab rather than as glass.
+alpha=30.0
 levcolor=['1.0', '1.0', '1.0', '1.0']
 levalpha=95.0
 levthickness=7.0
@@ -334,7 +382,12 @@ vpadding=10.0
 size=40.0
 bradius=100.0
 border=false
-shadow=true
+# Off because with bg-effect='none' Custom OSD takes its box-shadow branch, and
+# a shadow around a translucent rounded pill reads as a dark rectangle stamped
+# behind it — the same thing 0dcb16c removed from the menus.
+shadow=false
+# rotate and popup blur do not combine: Blur My Shell's blur actor is a sibling
+# of the pill and does not rotate with it.
 rotate=false
 square-circle=false
 horizontal=0.0

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,7 @@ WANT_PANEL_BLUR_FIX=1
 WANT_BMS_GIT=1
 WANT_POPUP_BLUR=1
 POPUP_BLUR_EXPLICIT=""
+WANT_ROUNDED_BLUR=1
 CURSORS="adwaita"   # adwaita | mactahoe
 ICONS=""            # empty = remembered choice, then colloid
 GRAIN=""          # empty keeps the preset's value, or the remembered choice
@@ -71,6 +72,10 @@ ${C_BLD}tahoe-glass${C_OFF} — a macOS Tahoe glass desktop for GNOME 48-50
     --no-bms-git      use Blur My Shell's published build instead of the pinned
                       git one. That build has no popup component, so it
                       implies --no-popup-blur
+    --no-rounded-blur skip gnome-rounded-blur. It is the only thing installed
+                      outside \$HOME and it always asks first, --yes included.
+                      Without it the popup blur is still rounded, it just
+                      samples the wallpaper instead of the window behind it
     --no-icons        keep your current icon theme
     --no-cursors      keep your current cursor theme
     --no-wm-buttons   keep your current titlebar button layout
@@ -96,9 +101,10 @@ while [ $# -gt 0 ]; do
         # later so that anything after it still wins: --full --no-osd is the
         # lot minus the OSD. It deliberately leaves --cursors alone — MacTahoe
         # cursors are a different look, not a more complete one.
-        # --bms-git and --popup-blur are already on by default and so are not
-        # repeated here; --rounded-blur is deliberately left out, because it is
-        # the one step that installs a system package.
+        # --bms-git, --popup-blur and --rounded-blur are already on by default
+        # and so are not repeated here. Note that --full does not make the
+        # rounded-blur step any less interactive: it is the one step that
+        # installs outside $HOME and it always asks, --yes included.
         --full)          WANT_EXTRAS=1; WANT_ICONS=1; WANT_CURSORS=1
                          WANT_WM_BUTTONS=1; WANT_OSD=1; WANT_PANEL_BLUR_FIX=1
                          shift ;;
@@ -121,6 +127,8 @@ while [ $# -gt 0 ]; do
         --popup-blur)    WANT_POPUP_BLUR=1; WANT_BMS_GIT=1
                          POPUP_BLUR_EXPLICIT=1; shift ;;
         --no-popup-blur) WANT_POPUP_BLUR=0; POPUP_BLUR_EXPLICIT=1; shift ;;
+        --rounded-blur)      WANT_ROUNDED_BLUR=1; shift ;;
+        --no-rounded-blur)   WANT_ROUNDED_BLUR=0; shift ;;
         --no-icons)      WANT_ICONS=0; shift ;;
         --no-cursors)    WANT_CURSORS=0; shift ;;
         --no-wm-buttons) WANT_WM_BUTTONS=0; shift ;;
@@ -183,6 +191,10 @@ fi
 
 install_theme
 install_extensions
+# Before load_dconf, so apply_popup_blur sees the result. On a first install it
+# will still pick static: Blur My Shell only writes rounded-blur-found once the
+# shell has loaded this build, which is the next login.
+install_rounded_blur
 if [ "$WANT_ICONS" = 1 ]; then install_icons; else step "Icons"; skip "left alone (--no-icons)"; fi
 if [ "$WANT_CURSORS" = 1 ]; then install_cursors; else step "Cursors"; skip "left alone (--no-cursors)"; fi
 load_dconf

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,9 @@ WANT_WM_BUTTONS=1
 WANT_DEPS=1
 WANT_OSD=1
 WANT_PANEL_BLUR_FIX=1
+WANT_BMS_GIT=1
+WANT_POPUP_BLUR=1
+POPUP_BLUR_EXPLICIT=""
 CURSORS="adwaita"   # adwaita | mactahoe
 ICONS=""            # empty = remembered choice, then colloid
 GRAIN=""          # empty keeps the preset's value, or the remembered choice
@@ -63,6 +66,11 @@ ${C_BLD}tahoe-glass${C_OFF} — a macOS Tahoe glass desktop for GNOME 48-50
     --no-osd          keep the stock volume and brightness popup. By default
                       it is reduced to its level bar — no icon, no device
                       name — on a blurred pill
+    --no-popup-blur   keep the flat translucent popups and skip the blur
+                      behind menus, quick settings, notifications and the OSD
+    --no-bms-git      use Blur My Shell's published build instead of the pinned
+                      git one. That build has no popup component, so it
+                      implies --no-popup-blur
     --no-icons        keep your current icon theme
     --no-cursors      keep your current cursor theme
     --no-wm-buttons   keep your current titlebar button layout
@@ -88,6 +96,9 @@ while [ $# -gt 0 ]; do
         # later so that anything after it still wins: --full --no-osd is the
         # lot minus the OSD. It deliberately leaves --cursors alone — MacTahoe
         # cursors are a different look, not a more complete one.
+        # --bms-git and --popup-blur are already on by default and so are not
+        # repeated here; --rounded-blur is deliberately left out, because it is
+        # the one step that installs a system package.
         --full)          WANT_EXTRAS=1; WANT_ICONS=1; WANT_CURSORS=1
                          WANT_WM_BUTTONS=1; WANT_OSD=1; WANT_PANEL_BLUR_FIX=1
                          shift ;;
@@ -102,6 +113,14 @@ while [ $# -gt 0 ]; do
         --icons=*)       ICONS="${1#*=}"; shift ;;
         --osd)           WANT_OSD=1; shift ;;
         --no-osd)        WANT_OSD=0; shift ;;
+        # The published Blur My Shell has no popup schema at all, so asking for
+        # one without the other cannot work. Each flag drags the other along.
+        --bms-git)       WANT_BMS_GIT=1; shift ;;
+        --no-bms-git)    WANT_BMS_GIT=0; WANT_POPUP_BLUR=0
+                         POPUP_BLUR_EXPLICIT=1; shift ;;
+        --popup-blur)    WANT_POPUP_BLUR=1; WANT_BMS_GIT=1
+                         POPUP_BLUR_EXPLICIT=1; shift ;;
+        --no-popup-blur) WANT_POPUP_BLUR=0; POPUP_BLUR_EXPLICIT=1; shift ;;
         --no-icons)      WANT_ICONS=0; shift ;;
         --no-cursors)    WANT_CURSORS=0; shift ;;
         --no-wm-buttons) WANT_WM_BUTTONS=0; shift ;;

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -43,6 +43,24 @@ confirm() {
     esac
 }
 
+# confirm_always "question" — like confirm, but --yes does not answer it and a
+# non-interactive run declines instead of defaulting. For the one step that
+# installs a package outside $HOME: saying yes to a theme installer is not the
+# same as saying yes to that, and neither is piping this script into bash.
+confirm_always() {
+    local q="$1" ans
+    if [ ! -t 0 ]; then
+        warn "not an interactive terminal — declining. Re-run in a terminal to accept."
+        return 1
+    fi
+    printf '    %s [y/N] ' "$q" >&2
+    read -r ans || ans=''
+    case "${ans,,}" in
+        y|yes) return 0 ;;
+        *)     return 1 ;;
+    esac
+}
+
 have() { command -v "$1" >/dev/null 2>&1; }
 
 # Clone at a pinned ref, or fetch that ref into an existing clone. Pinning

--- a/lib/distro.sh
+++ b/lib/distro.sh
@@ -37,17 +37,26 @@ detect_distro() {
 declare -A PKG_ARCH=(
     [git]=git [curl]=curl [unzip]=unzip [sassc]=sassc
     [gsettings]=glib2 [dconf]=dconf [gnome-extensions]=gnome-shell
+    [msgfmt]=gettext
 )
 declare -A PKG_FEDORA=(
     [git]=git [curl]=curl [unzip]=unzip [sassc]=sassc
     [gsettings]=glib2 [dconf]=dconf [gnome-extensions]=gnome-shell
+    [msgfmt]=gettext
 )
 declare -A PKG_DEBIAN=(
     [git]=git [curl]=curl [unzip]=unzip [sassc]=sassc
     [gsettings]=libglib2.0-bin [dconf]=dconf-cli [gnome-extensions]=gnome-shell
+    [msgfmt]=gettext
 )
 
 REQUIRED_CMDS=(git curl unzip sassc gsettings dconf gnome-extensions)
+
+# Nice to have, never fatal. msgfmt compiles Blur My Shell's translations when
+# it is built from git; without it the extension works and its preferences are
+# simply untranslated. Kept out of REQUIRED_CMDS so a missing gettext cannot
+# block the whole install over a cosmetic loss.
+OPTIONAL_CMDS=(msgfmt)
 
 missing_cmds() {
     local c
@@ -68,6 +77,12 @@ install_hint() {
 install_deps() {
     local missing=() c
     while IFS= read -r c; do [ -n "$c" ] && missing+=("$c"); done < <(missing_cmds)
+
+    # Reported but never installed or waited on: an optional command going
+    # missing should read as a note, not as something the user has to act on.
+    local opt=() o
+    for o in "${OPTIONAL_CMDS[@]}"; do have "$o" || opt+=("$o"); done
+    [ ${#opt[@]} -gt 0 ] && info "optional, not installed: ${opt[*]}"
 
     if [ ${#missing[@]} -eq 0 ]; then
         ok "all dependencies present"

--- a/lib/steps.sh
+++ b/lib/steps.sh
@@ -10,6 +10,9 @@ BMS_REPO="https://github.com/aunetx/blur-my-shell.git"
 BMS_REF="7d1290bbcff9"            # master; no release carries the popup component
 BMS_UUID="blur-my-shell@aunetx"
 
+ROUNDEDBLUR_REPO="https://github.com/kancko/gnome-rounded-blur.git"
+ROUNDEDBLUR_REF="9c7efb7ac5de"    # v1.0.1
+
 OPENBAR_REPO="https://github.com/neuromorph/openbar.git"
 OPENBAR_REF="01fb24217e0c"       # last upstream commit; patched for GNOME 50
 
@@ -399,6 +402,108 @@ install_custom_osd() {
     glib-compile-schemas "$EXT_DIR/$uuid/schemas" \
         || die "failed to compile Custom OSD's gsettings schemas"
     ok "$uuid (patched for GNOME $GNOME_MAJOR)"
+}
+
+# Blur My Shell gets rounded corners on a *dynamic* blur from Blur.BlurEffect,
+# which comes from this small C library — a vendored copy of gnome-shell's own
+# shell-blur-effect.c with a corner mask. Without it the popup blur falls back
+# to static, which still rounds (see apply_popup_blur); this is the upgrade
+# from "blurred wallpaper" to "blurred whatever is actually behind the popup".
+#
+# It is the only thing this project installs outside $HOME, so it is the only
+# step that asks first — and it asks even under --yes, because agreeing to a
+# theme installer is not the same as agreeing to a package from the AUR.
+#
+# It hard-pins libmutter-18, so every mutter update breaks it until it is
+# rebuilt. That failure is silent by design upstream: Blur My Shell just falls
+# back to Shell.BlurEffect. rounded_blur_staleness_check is what makes it loud.
+install_rounded_blur() {
+    step "Rounded corners for dynamic blur"
+
+    if [ "${WANT_ROUNDED_BLUR:-1}" != 1 ]; then
+        skip "not installed (--no-rounded-blur) — popup blur stays static"
+        return 0
+    fi
+
+    if gjs -c 'imports.gi.Blur;' >/dev/null 2>&1 && [ "${FORCE:-0}" != 1 ]; then
+        skip "gnome-rounded-blur already installed"
+        rounded_blur_stamp
+        return 0
+    fi
+
+    local helper='' h
+    for h in paru yay; do have "$h" && { helper="$h"; break; }; done
+
+    if [ -z "$helper" ] && ! have meson; then
+        warn "neither an AUR helper (paru/yay) nor meson is installed."
+        warn "Popup blur still works and its corners are still round — it just"
+        warn "samples the wallpaper instead of the window behind it."
+        return 0
+    fi
+
+    local cmd
+    if [ -n "$helper" ]; then
+        cmd="$helper -S --needed gnome-rounded-blur"
+    else
+        cmd="meson setup --prefix=/usr build && sudo meson install -C build"
+    fi
+
+    info "this is the one part of tahoe-glass that installs outside \$HOME:"
+    info "    $cmd"
+    if ! confirm_always "Install gnome-rounded-blur? It needs root."; then
+        skip "not installed — popup blur stays static, and still rounded"
+        return 0
+    fi
+
+    if [ "${DRY_RUN:-0}" = 1 ]; then
+        info "dry-run: $cmd"
+        return 0
+    fi
+
+    if [ -n "$helper" ]; then
+        "$helper" -S --needed gnome-rounded-blur \
+            || { warn "the AUR build failed — popup blur stays static"; return 0; }
+    else
+        local src="$SRC_CACHE/gnome-rounded-blur"
+        clone_pinned "$ROUNDEDBLUR_REPO" "$ROUNDEDBLUR_REF" "$src"
+        ( cd "$src" && rm -rf build \
+            && meson setup --prefix=/usr build \
+            && meson compile -C build \
+            && sudo meson install -C build ) \
+            || { warn "the meson build failed — popup blur stays static"; return 0; }
+    fi
+
+    if gjs -c 'imports.gi.Blur;' >/dev/null 2>&1; then
+        rounded_blur_stamp
+        ok "gnome-rounded-blur installed — popup blur can be dynamic"
+        info "it is compiled against this mutter, so re-run with --rounded-blur --force after a mutter update"
+    else
+        warn "installed, but the shell still cannot import gi://Blur"
+    fi
+}
+
+# Records the mutter it was built against, which is what makes staleness
+# detectable later.
+rounded_blur_stamp() {
+    [ "${DRY_RUN:-0}" = 1 ] && return 0
+    mkdir -p "$CONF_DIR"
+    printf '%s\n' "$(pkg-config --modversion libmutter-18 2>/dev/null || gnome_major)" \
+        > "$CONF_DIR/rounded-blur"
+}
+
+# Blur My Shell publishes the answer itself: it writes rounded-blur-found at
+# every enable. If this machine installed the library but the shell is no
+# longer finding it, mutter has moved and the library needs rebuilding.
+rounded_blur_staleness_check() {
+    [ -f "$CONF_DIR/rounded-blur" ] || return 0
+    local found
+    found="$(dconf read /org/gnome/shell/extensions/blur-my-shell/rounded-blur-found 2>/dev/null || true)"
+    [ "$found" = false ] || return 0
+    warn "gnome-rounded-blur is installed here, but the shell is not finding it."
+    warn "Mutter has probably been updated — it has to be rebuilt against it:"
+    warn "    ./install.sh --rounded-blur --force"
+    warn "Until then the popup blur falls back to static. Still rounded, but it"
+    warn "samples the wallpaper rather than the window behind it."
 }
 
 install_extensions() {
@@ -1021,6 +1126,9 @@ install_panel_blur_unit() {
 }
 
 finish() {
+    # Runs whether or not --rounded-blur was passed, so a machine whose library
+    # went stale after a mutter update finds out on the next install either way.
+    rounded_blur_staleness_check
     step "Done"
     cat <<EOF
 

--- a/lib/steps.sh
+++ b/lib/steps.sh
@@ -6,6 +6,10 @@
 THEME_REPO="https://github.com/kayozxo/GNOME-macOS-Tahoe.git"
 THEME_REF="6dfcd9d941e5"
 
+BMS_REPO="https://github.com/aunetx/blur-my-shell.git"
+BMS_REF="7d1290bbcff9"            # master; no release carries the popup component
+BMS_UUID="blur-my-shell@aunetx"
+
 OPENBAR_REPO="https://github.com/neuromorph/openbar.git"
 OPENBAR_REF="01fb24217e0c"       # last upstream commit; patched for GNOME 50
 
@@ -26,11 +30,12 @@ CONF_DIR="$HOME/.config/tahoe-glass"
 BACKUP_DIR="$CONF_DIR/backups"
 SRC_CACHE="$HOME/.cache/tahoe-glass/src"
 
-# Everything the look actually needs. openbar is absent because it installs
-# differently on GNOME 50 — see install_openbar.
+# Everything the look actually needs that comes straight from the extensions
+# site. openbar, custom-osd and blur-my-shell are absent because each is built
+# from a pinned commit instead — see install_openbar, install_custom_osd and
+# install_bms.
 EXT_CORE=(
     user-theme@gnome-shell-extensions.gcampax.github.com
-    blur-my-shell@aunetx
 )
 # The rest of the reference desktop, in the order the shell lays them out.
 # None of it is required, and --extras is what asks for it.
@@ -209,6 +214,103 @@ install_ext_ego() {
     return "$rc"
 }
 
+# Blur My Shell's published build (v72) has no popup component: menus, quick
+# settings, notifications, dialogs and the OSD get no blur at all. That is why
+# css/shell-tweaks.css paints its own flat translucency behind them, and why the
+# OSD used to carry a hand-rolled corner shader. Upstream's master has the
+# component; there is no release with it yet, so it is built from a pinned
+# commit. gnome-extensions pack and gnome-extensions install both write under
+# $HOME, so this needs no root.
+install_bms() {
+    if [ "${WANT_BMS_GIT:-1}" != 1 ]; then
+        install_ext_ego "$BMS_UUID" || true
+        if [ "${DRY_RUN:-0}" != 1 ]; then
+            mkdir -p "$CONF_DIR"
+            printf 'ego\n' > "$CONF_DIR/bms-source"
+            rm -f "$CONF_DIR/bms-ref"
+        fi
+        skip "Blur My Shell from extensions.gnome.org (--no-bms-git) — no popup blur"
+        return 0
+    fi
+
+    # master still declares "version": 72, the same as the published build, so
+    # the version number cannot tell the two apart. Probe for the component and
+    # check the stamp — the directory test matters on its own because
+    # ./uninstall.sh --extensions removes the extension but leaves $CONF_DIR.
+    if [ "${FORCE:-0}" != 1 ] \
+       && [ -f "$EXT_DIR/$BMS_UUID/components/popup/index.js" ] \
+       && [ "$(cat "$CONF_DIR/bms-ref" 2>/dev/null || true)" = "$BMS_REF" ] \
+       && ext_supports_shell "$EXT_DIR/$BMS_UUID" "$GNOME_MAJOR"; then
+        skip "$BMS_UUID already built from $BMS_REF"
+        return 0
+    fi
+
+    info "no release carries the popup component — building from $BMS_REF"
+    local src="$SRC_CACHE/blur-my-shell"
+    clone_pinned "$BMS_REPO" "$BMS_REF" "$src"
+
+    local podir=(--podir=../po)
+    if ! have msgfmt; then
+        warn "msgfmt not found (install gettext) — building without translations"
+        podir=()
+    fi
+
+    if [ "${DRY_RUN:-0}" = 1 ]; then
+        info "dry-run: gnome-extensions pack in $src/src, then install the zip"
+        return 0
+    fi
+
+    # This mirrors upstream's Makefile 'build' target rather than calling make,
+    # because make is not one of this project's dependencies. Doing it here also
+    # means a failed build never gets as far as deleting the working extension.
+    # The mkdir is not optional: given a -o directory that does not exist,
+    # gnome-extensions pack segfaults (139) instead of reporting an error.
+    rm -rf "$src/build"
+    mkdir -p "$src/build"
+    ( cd "$src/src" && gnome-extensions pack -f \
+        --extra-source=../metadata.json \
+        --extra-source=../LICENSE \
+        --extra-source=../resources/icons \
+        --extra-source=../resources/ui \
+        --extra-source=./components \
+        --extra-source=./conveniences \
+        --extra-source=./effects \
+        --extra-source=./preferences \
+        --extra-source=./dbus \
+        --extra-source=./styles \
+        "${podir[@]}" \
+        --schema=../schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml \
+        -o ../build ) >/dev/null \
+        || die "packing Blur My Shell failed — upstream's layout may have moved"
+
+    local zip="$src/build/$BMS_UUID.shell-extension.zip"
+    [ -f "$zip" ] || die "expected $zip after packing, but it is not there"
+    ext_supports_shell "$zip" "$GNOME_MAJOR" \
+        || die "the pinned Blur My Shell does not support GNOME $GNOME_MAJOR"
+
+    # Upstream's Makefile removes the directory before installing, and it is
+    # right to: v72 keeps its components as flat files where master keeps
+    # directories, so an overlay would leave both and load the wrong one.
+    # Settings live in dconf, not here, so nothing is lost. This runs only
+    # after the zip exists and has been checked.
+    rm -rf "$EXT_DIR/$BMS_UUID"
+    gnome-extensions install --force "$zip" >/dev/null \
+        || die "installing Blur My Shell failed"
+
+    # gnome-extensions install compiles the schema itself, but the whole popup
+    # section is unreadable if it ever stops, and that would show up as the
+    # preset silently doing nothing rather than as an error.
+    if [ ! -f "$EXT_DIR/$BMS_UUID/schemas/gschemas.compiled" ]; then
+        glib-compile-schemas "$EXT_DIR/$BMS_UUID/schemas" \
+            || die "failed to compile Blur My Shell's gsettings schemas"
+    fi
+
+    mkdir -p "$CONF_DIR"
+    printf '%s\n' "$BMS_REF" > "$CONF_DIR/bms-ref"
+    printf 'git\n' > "$CONF_DIR/bms-source"
+    ok "$BMS_UUID (built from $BMS_REF, with the popup component)"
+}
+
 # Open Bar is the one extension with no GNOME 50 release. Upstream's last
 # commit targets 49, so on 50 it is built from that commit plus the patch in
 # patches/. On 49 and below the published build is used unchanged.
@@ -304,6 +406,7 @@ install_extensions() {
     step "Installing shell extensions"
     local u
     for u in "${EXT_CORE[@]}"; do install_ext_ego "$u" || true; done
+    install_bms
     install_openbar
     install_custom_osd
 
@@ -315,7 +418,9 @@ install_extensions() {
 
 enable_extensions() {
     step "Enabling extensions"
-    local want=("${EXT_CORE[@]}" openbar@neuromorph) u
+    # $BMS_UUID is named explicitly rather than left in EXT_CORE so that it is
+    # enabled whichever source install_bms took it from.
+    local want=("${EXT_CORE[@]}" "$BMS_UUID" openbar@neuromorph) u
     [ "${WANT_OSD:-1}" = 1 ] && want+=(custom-osd@neuromorph)
     [ "${WANT_EXTRAS:-0}" = 1 ] && want+=("${EXT_EXTRA[@]}")
 

--- a/lib/steps.sh
+++ b/lib/steps.sh
@@ -354,9 +354,8 @@ install_openbar() {
 # own. Upstream's last release is for GNOME 46 and its last commit does not run
 # on 50 — the ShellBlurEffect:sigma property, the meta_*_clutter_debug_flags()
 # calls and OsdWindowManager.show()'s signature have all gone since. The patch
-# in patches/ fixes those, and rounds the blur to the popup's corners: a
-# background blur covers the actor's bounding box, so without it the pill sits
-# in a hard-edged rectangle of blur no matter what radius is set.
+# in patches/ fixes exactly those and nothing else. The blur behind the pill,
+# and the rounding of it, come from Blur My Shell's popup component.
 install_custom_osd() {
     local uuid="custom-osd@neuromorph"
 
@@ -693,6 +692,15 @@ install_css() {
     run install -Dm644 "$REPO_ROOT/css/gtk4-tweaks.css"  "$CONF_DIR/gtk4-tweaks.css"
     run install -Dm644 "$REPO_ROOT/css/gtk3-tweaks.css"  "$CONF_DIR/gtk3-tweaks.css"
     run install -Dm755 "$REPO_ROOT/bin/tahoe-glass-apply" "$HOME/.local/bin/tahoe-glass-apply"
+
+    # Installed or removed rather than switched on at read time: tahoe-glass-apply
+    # concatenates whatever it finds in $CONF_DIR and has no way to know which
+    # options this install was given.
+    if [ "${WANT_POPUP_BLUR:-1}" = 1 ]; then
+        run install -Dm644 "$REPO_ROOT/css/shell-popup-blur.css" "$CONF_DIR/shell-popup-blur.css"
+    else
+        run rm -f "$CONF_DIR/shell-popup-blur.css"
+    fi
     ok "css -> $CONF_DIR"
     ok "re-apply command -> ~/.local/bin/tahoe-glass-apply"
 
@@ -747,7 +755,57 @@ load_dconf() {
     run dconf write /org/gnome/shell/extensions/openbar/trigger-reload true
 
     apply_grain
+    apply_popup_blur
     sync_osd_profile
+}
+
+# The popup keys themselves ship in dconf/core.ini so the whole preset stays
+# readable in one file. Two things cannot live there:
+#
+# The on/off choice, because dconf load rewrites the section on every run — a
+# flagless re-install would quietly turn popup blur back on over a deliberate
+# --no-popup-blur. Same reason --grain and --icons are remembered.
+#
+# static-blur, because the right value depends on the machine. Rounded corners
+# on a dynamic blur need the gnome-rounded-blur library; a static blur rounds
+# itself. So when the library is missing this falls back to static, and the
+# corners stay round instead of going square. It self-heals: install the
+# library, re-run, and it flips back to dynamic.
+apply_popup_blur() {
+    local base=/org/gnome/shell/extensions/blur-my-shell
+    local want="${WANT_POPUP_BLUR:-1}" memo="$CONF_DIR/popup-blur"
+
+    if [ -z "${POPUP_BLUR_EXPLICIT:-}" ] && [ -r "$memo" ]; then
+        want="$(cat "$memo" 2>/dev/null || true)"
+        want="${want:-1}"
+    fi
+
+    if [ "${DRY_RUN:-0}" != 1 ]; then
+        mkdir -p "$CONF_DIR"
+        printf '%s\n' "$want" > "$memo"
+    fi
+
+    if [ "$want" != 1 ]; then
+        run dconf write "$base/popup/blur" false
+        skip "popup blur off — menus keep the flat translucent look"
+        return 0
+    fi
+
+    # Written by Blur My Shell at every enable, so on a first install — before
+    # the shell has ever loaded this build — it is absent and we start static.
+    # The next run picks the library up.
+    local found
+    found="$(dconf read "$base/rounded-blur-found" 2>/dev/null || true)"
+
+    run dconf write "$base/popup/blur" true
+    if [ "$found" = true ]; then
+        run dconf write "$base/popup/static-blur" false
+        ok "popup blur on, dynamic — it tracks whatever is behind the popup"
+    else
+        run dconf write "$base/popup/static-blur" true
+        ok "popup blur on, static — rounded, but sampling the wallpaper"
+        info "install gnome-rounded-blur (--rounded-blur) for blur that tracks windows"
+    fi
 }
 
 # Custom OSD keeps a set of named profiles beside the live settings, and its

--- a/patches/custom-osd-gnome50.patch
+++ b/patches/custom-osd-gnome50.patch
@@ -1,14 +1,8 @@
 diff --git a/extension.js b/extension.js
-index 27fbac8..95326df 100644
+index 27fbac8..0740354 100644
 --- a/extension.js
 +++ b/extension.js
-@@ -1,4 +1,5 @@
- import Clutter from 'gi://Clutter';
-+import Cogl from 'gi://Cogl';
- import St from 'gi://St';
- import GObject from 'gi://GObject';
- import Gio from 'gi://Gio';
-@@ -14,6 +15,101 @@ import {Extension, gettext as _, pgettext} from 'resource:///org/gnome/shell/ext
+@@ -14,6 +14,50 @@ import {Extension, gettext as _, pgettext} from 'resource:///org/gnome/shell/ext
  
  const OsdWindowManager = Main.osdWindowManager;
  
@@ -45,57 +39,6 @@ index 27fbac8..95326df 100644
 +}
 +
 +const BLUR_EFFECT = 'customOSD-dynamic';
-+const CORNER_EFFECT = 'customOSD-corner';
-+
-+// Shell.BlurEffect blurs the actor's bounding box and knows nothing about
-+// border-radius, so a rounded popup ends up sitting in a square patch of blur
-+// that no amount of styling can cover — the blur is the outermost thing drawn.
-+// This clips the finished paint, blur included, back to the rounded shape.
-+const CORNER_SHADER = `
-+uniform sampler2D tex;
-+uniform float width;
-+uniform float height;
-+uniform float radius;
-+
-+void main() {
-+    vec2 size = vec2(width, height);
-+    vec2 pos = cogl_tex_coord_in[0].xy * size;
-+    vec2 corner = min(pos, size - pos);
-+    float dist = length(max(vec2(radius) - corner, vec2(0.0))) - radius;
-+    float mask = 1.0 - smoothstep(-0.75, 0.75, dist);
-+    cogl_color_out = texture2D(tex, cogl_tex_coord_in[0].xy) * mask;
-+}
-+`;
-+
-+const CornerEffect = GObject.registerClass(
-+class CustomOSDCornerEffect extends Clutter.ShaderEffect {
-+  _init() {
-+    // Clutter 18 (GNOME 50) dropped ClutterShaderType; the shader-type
-+    // property is a CoglShaderType now, and it is construct-only either way.
-+    const fragment = Clutter.ShaderType
-+      ? Clutter.ShaderType.FRAGMENT_SHADER
-+      : Cogl.ShaderType.FRAGMENT;
-+    super._init({shader_type: fragment});
-+    this.set_uniform_value('tex', 0);
-+    this._geometry = null;
-+  }
-+
-+  vfunc_get_static_shader_source() {
-+    return CORNER_SHADER;
-+  }
-+
-+  setGeometry(width, height, radius) {
-+    const key = `${width}x${height}r${radius}`;
-+    if (this._geometry === key)
-+      return;
-+    this._geometry = key;
-+    // A float that lands on a whole number marshals as an int, which the
-+    // shader's float uniforms reject, so nudge every value off the integers.
-+    this.set_uniform_value('width', width + 0.0001);
-+    this.set_uniform_value('height', height + 0.0001);
-+    this.set_uniform_value('radius', radius + 0.0001);
-+  }
-+});
 +
 +// GNOME 50 replaced OsdWindowManager.show(monitorIndex, ...), where -1 meant
 +// every monitor, with show(icon, label, {[index]: {level, maxLevel}}) and a
@@ -110,7 +53,7 @@ index 27fbac8..95326df 100644
  export default class CustomOSDExtension extends Extension {
    constructor(metadata) {
      super(metadata);
-@@ -42,11 +138,11 @@ export default class CustomOSDExtension extends Extension {
+@@ -42,11 +86,11 @@ export default class CustomOSDExtension extends Extension {
    }
  
    _showOSD(osd) {
@@ -125,7 +68,7 @@ index 27fbac8..95326df 100644
      }
      if (osd == "Command OSD") {
        let cmdosd = this._settings.get_string('showosd');
-@@ -56,9 +152,9 @@ export default class CustomOSDExtension extends Extension {
+@@ -56,9 +100,9 @@ export default class CustomOSDExtension extends Extension {
        let level = parseFloat(cmdosd[3]);
        icon? icon = Gio.ThemedIcon.new_with_default_fallbacks(icon) : icon = this._custOSDIcon;
        if (level!=0 && !level)
@@ -137,7 +80,7 @@ index 27fbac8..95326df 100644
      }
    }
    
-@@ -318,17 +414,29 @@ export default class CustomOSDExtension extends Extension {
+@@ -318,17 +362,27 @@ export default class CustomOSDExtension extends Extension {
        
        // DYNAMIC BLUR
        else if (bgeffect == "dynamic-blur") {
@@ -152,15 +95,13 @@ index 27fbac8..95326df 100644
 -              mode: Shell.BlurMode.BACKGROUND, 
 -          });
 +        // Upstream drops the background entirely here. Keeping the translucent
-+        // fill is what makes this read as glass rather than as a smudge, and
-+        // the rounded corners below are what stop it reading as a rectangle.
++        // fill is what makes this read as glass rather than as a smudge.
 +        //
-+        // The corner effect has to go on first: Clutter runs the effect added
-+        // first as the outermost one, so it wraps — and therefore clips — the
-+        // blur painted after it.
-+        if (!osdW._hbox.get_effect(CORNER_EFFECT))
-+          osdW._hbox.add_effect_with_name(CORNER_EFFECT, new CornerEffect());
-+
++        // This blur covers the actor's bounding box and knows nothing about
++        // border-radius, so the pill sits in a square patch of it. That is why
++        // the preset ships bg-effect='none' and lets Blur My Shell's popup
++        // component blur the OSD instead: it clips to the corner radius, on
++        // every GPU, and it is maintained upstream.
 +        let effect = osdW._hbox.get_effect(BLUR_EFFECT);
 +        if (!effect) {
 +          effect = new Shell.BlurEffect({name: BLUR_EFFECT});
@@ -177,7 +118,7 @@ index 27fbac8..95326df 100644
        }
  
        // GLASS OR WOOD RAW OR WOOD POLISHED
-@@ -346,11 +454,11 @@ export default class CustomOSDExtension extends Extension {
+@@ -346,11 +400,9 @@ export default class CustomOSDExtension extends Extension {
        }
  
        if (bgeffect != "dynamic-blur") {
@@ -188,13 +129,11 @@ index 27fbac8..95326df 100644
 -      }      
 +        if (osdW._hbox.get_effect(BLUR_EFFECT))
 +          osdW._hbox.remove_effect_by_name(BLUR_EFFECT);
-+        if (osdW._hbox.get_effect(CORNER_EFFECT))
-+          osdW._hbox.remove_effect_by_name(CORNER_EFFECT);
 +      }
        
        osdW._hbox.style = hboxSty;
  
-@@ -410,13 +518,13 @@ export default class CustomOSDExtension extends Extension {
+@@ -410,13 +462,11 @@ export default class CustomOSDExtension extends Extension {
        if (osdW._hideTimeoutId)
          GLib.source_remove(osdW._hideTimeoutId);
  
@@ -204,8 +143,6 @@ index 27fbac8..95326df 100644
 -      }
 +      if (osdW._hbox.get_effect(BLUR_EFFECT))
 +        osdW._hbox.remove_effect_by_name(BLUR_EFFECT);
-+      if (osdW._hbox.get_effect(CORNER_EFFECT))
-+        osdW._hbox.remove_effect_by_name(CORNER_EFFECT);
  
        if (osdW._blurTimeoutId) {
 -        Meta.remove_clutter_debug_flags(null, Clutter.DrawDebugFlag.DISABLE_CLIPPED_REDRAWS, null);
@@ -213,7 +150,7 @@ index 27fbac8..95326df 100644
          GLib.source_remove(osdW._blurTimeoutId);
          osdW._blurTimeoutId = null;
        }
-@@ -462,13 +570,7 @@ export default class CustomOSDExtension extends Extension {
+@@ -462,13 +512,7 @@ export default class CustomOSDExtension extends Extension {
  
      // Check if Clipped Redraws flag is set externally (e.g. by Blur My Shell)
      this.redrawFlagTimeoutId = setTimeout( () => {
@@ -228,7 +165,7 @@ index 27fbac8..95326df 100644
      }, 2000);
  
   
-@@ -572,8 +674,15 @@ export default class CustomOSDExtension extends Extension {
+@@ -572,8 +616,8 @@ export default class CustomOSDExtension extends Extension {
  
          this._hbox.style += ` border-radius: ${br1*hbxH/2/100}px ${br2*hbxH/2/100}px;`;
  
@@ -236,17 +173,10 @@ index 27fbac8..95326df 100644
 -        
 +        let hbxW = this._hbox.width;
 +
-+        // The clip has to follow the pill, which changes width with the label
-+        // and the numeric %, and height with the square/circle setting.
-+        const corner = this._hbox.get_effect(CORNER_EFFECT);
-+        if (corner)
-+          corner.setGeometry(hbxW, hbxH, br1*hbxH/2/100);
-+
-+
          if(bgeffect == 'progress-ring') {
            custOSD.progressRing = true;
            custOSD.height = hbxH;
-@@ -601,14 +710,14 @@ export default class CustomOSDExtension extends Extension {
+@@ -601,14 +645,14 @@ export default class CustomOSDExtension extends Extension {
          let transY = -v_percent * (monitor.height - hbxH)/100.0;
          this._hbox.translation_y = transY;
  

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -183,6 +183,9 @@ fi
 step "Removing tahoe-glass itself"
 run rm -f "$HOME/.local/bin/tahoe-glass-apply" "$HOME/.local/bin/tahoe-glass-icon-sync" \
           "$HOME/.local/bin/tahoe-glass-panel-blur"
+# Stamps describing artifacts that have just been removed, rather than choices
+# the user made — so they go now instead of waiting on the $CONF_DIR prompt.
+run rm -f "$CONF_DIR/bms-ref" "$CONF_DIR/bms-source"
 if confirm "Delete $CONF_DIR (this also deletes the backups above)?" 0; then
     run rm -rf "$CONF_DIR"
     ok "removed"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -180,13 +180,24 @@ fi
 
 # ------------------------------------------------------------------ our own --
 
+if [ -f "$CONF_DIR/rounded-blur" ]; then
+    step "gnome-rounded-blur"
+    # Not removed from here: it is the one thing this project installs outside
+    # $HOME, and an uninstaller that runs sudo on your behalf is worse than one
+    # that tells you what to run.
+    info "installed into /usr by this project. To remove it:"
+    info "    sudo pacman -Rs gnome-rounded-blur       # if it came from the AUR"
+    info "    sudo ninja -C ~/.cache/tahoe-glass/src/gnome-rounded-blur/build uninstall"
+fi
+
 step "Removing tahoe-glass itself"
 run rm -f "$HOME/.local/bin/tahoe-glass-apply" "$HOME/.local/bin/tahoe-glass-icon-sync" \
           "$HOME/.local/bin/tahoe-glass-panel-blur"
 # Stamps describing artifacts that have just been removed, rather than choices
 # the user made — so they go now instead of waiting on the $CONF_DIR prompt.
 run rm -f "$CONF_DIR/bms-ref" "$CONF_DIR/bms-source" \
-          "$CONF_DIR/shell-popup-blur.css" "$CONF_DIR/popup-blur"
+          "$CONF_DIR/shell-popup-blur.css" "$CONF_DIR/popup-blur" \
+          "$CONF_DIR/rounded-blur"
 if confirm "Delete $CONF_DIR (this also deletes the backups above)?" 0; then
     run rm -rf "$CONF_DIR"
     ok "removed"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -185,7 +185,8 @@ run rm -f "$HOME/.local/bin/tahoe-glass-apply" "$HOME/.local/bin/tahoe-glass-ico
           "$HOME/.local/bin/tahoe-glass-panel-blur"
 # Stamps describing artifacts that have just been removed, rather than choices
 # the user made — so they go now instead of waiting on the $CONF_DIR prompt.
-run rm -f "$CONF_DIR/bms-ref" "$CONF_DIR/bms-source"
+run rm -f "$CONF_DIR/bms-ref" "$CONF_DIR/bms-source" \
+          "$CONF_DIR/shell-popup-blur.css" "$CONF_DIR/popup-blur"
 if confirm "Delete $CONF_DIR (this also deletes the backups above)?" 0; then
     run rm -rf "$CONF_DIR"
     ok "removed"


### PR DESCRIPTION
Stacked on #5.

Three bugs in this project had one root cause: the published Blur My Shell (v72) has **no popup component**. Menus, quick settings, notifications and the OSD got no blur at all, which is why `css/shell-tweaks.css` fakes it with flat translucency and why the OSD carried a hand-rolled corner shader.

That shader was the most fragile code here. Clutter sizes a `ShaderEffect`'s offscreen buffer to the actor's *paint volume* rather than its allocation, so it rendered a rounded pill on AMD and a hard square on Intel — `cogl_framebuffer_set_viewport: assertion 'width > 0 && height > 0' failed`, 111 times on one machine. Two fixes were attempted and reverted.

Upstream's `master` has the component. `src/effects/corner.js` is the same `Clutter.ShaderEffect` approach, but it clamps the radius to `min(radius * scale, width/2, height/2)` instead of being handed geometry a frame too early, and `osd-window` is already one of its targets. So ~120 lines come out of `patches/custom-osd-gnome50.patch` and `bg-effect` goes to `'none'`.

## static-blur is derived, not hardcoded

Rounded corners on a *dynamic* popup blur need `gnome-rounded-blur`; a *static* blur rounds itself. `apply_popup_blur` reads Blur My Shell's own `rounded-blur-found` key, so a machine without the library gets **round corners over a wallpaper blur** rather than **square corners over a live one**, and flips to dynamic by itself once the library is there.

`rounded-blur-found` is removed from the preset for the same reason — `dconf load` would have stamped it false moments before that check read it.

## Verified in an isolated headless session

Private D-Bus session + private XDG dirs (`DCONF_PROFILE` is not enough — the dconf client forwards writes to the *running* service).

- popup schema has all 13 keys; `bms-ref` stamp matches; second run skips; `--force` rebuilds
- **0** `cogl_framebuffer_set_viewport` assertions, **0** JS errors, in all three modes
- static → rounded capsule, blurred wallpaper
- dynamic without the library → correct content, **hard 90° corners** — i.e. the reported bug, reproduced, and the reason the fallback prefers static
- `--no-popup-blur` writes `popup/blur false` and installs no extra CSS

Two bugs found by running it rather than reasoning: `gnome-extensions pack` **segfaults (139)** when `-o` names a missing directory, and `metadata.json` on master still says `"version": 72`, so the version cannot discriminate the builds (idempotence keys off `components/popup/index.js` + a stamp).

## Still needs a real session
Corner rendering on Intel graphics. Nothing headless proves that machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)