### PR TITLE
--app-transparency, so the blur behind windows is visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Have a look first if you like — nothing is written:
 | `--extras` | also install the rest of the reference desktop — see below |
 | `--icons WHICH` | `colloid` (default, follows `--accent`) or `reversal-COLOUR` |
 | `--cursors WHICH` | `adwaita` (default) or `mactahoe` |
+| `--app-transparency N` | translucent app windows, `0.70`–`1.00` (default `0.92`). Off unless asked for |
 | `--no-osd` | keep the stock volume/brightness popup |
+| `--no-popup-blur` | keep flat translucent popups, no blur behind them |
+| `--no-rounded-blur` | skip `gnome-rounded-blur` — popup blur stays static |
+| `--no-bms-git` | use Blur My Shell's published build (no popup component) |
 | `--no-icons` | keep your icon theme |
 | `--no-cursors` | keep your cursor theme |
 | `--no-wm-buttons` | keep your titlebar button layout |
@@ -96,6 +100,61 @@ switching **Settings → Appearance** to Light would restyle everything except
 the icons. `tahoe-glass-icon-sync.service` watches the colour scheme and keeps
 the key pointing at the matching variant.
 
+### Popup blur
+
+Menus, quick settings, notifications, dialogs, the alt-tab switcher and the
+volume/brightness OSD all sit on a real blur.
+
+This is why Blur My Shell is built from a pinned commit rather than taken from
+extensions.gnome.org: the popup component only exists on upstream's `master`,
+and no release carries it yet. When one does, this project will go back to the
+published build.
+
+There are two modes, and the difference is what the blur samples:
+
+- **dynamic** — whatever is actually behind the popup. This is the default, and
+  it needs [`gnome-rounded-blur`][roundedblur], a small C library that gives
+  Blur My Shell's dynamic blur a corner mask. Without it the blur still works
+  but the corners come out square.
+- **static** — the wallpaper, blurred once. Needs nothing extra, and rounds its
+  own corners.
+
+The installer picks between them from Blur My Shell's own `rounded-blur-found`
+key rather than assuming: library present means dynamic, absent means static.
+So declining the library, or a mutter update breaking it, costs you *what the
+blur samples* rather than the shape — round over the wallpaper, instead of
+square over the window. Re-run `./install.sh --rounded-blur --force` to rebuild
+it and the mode flips back on its own.
+
+`gnome-rounded-blur` is the only thing this project installs outside `$HOME`,
+so it is the only step that asks first — and it asks even under `--yes`. It is
+compiled against your current mutter and has to be rebuilt after a mutter
+update; the installer notices that case and says so.
+
+`--no-popup-blur` reverts to the flat translucent popups this project shipped
+before, exactly.
+
+### App transparency
+
+Blur My Shell can blur behind app windows, but libadwaita paints opaque
+backgrounds, so by default there is nothing to see through. `--app-transparency`
+makes the surfaces libadwaita actually paints translucent — the window, header
+bar, sidebar panes, content views and popovers.
+
+It is **off by default and not part of `--full`**, because it only works for
+apps that use GTK's stylesheet. These will ignore it and stay opaque:
+
+- Electron and Chromium apps — VS Code, Discord, Slack, Brave
+- Steam, Java/Swing apps, LibreOffice
+- anything drawing a GL or video surface — mpv, Totem's video widget
+- XWayland apps generally, and GTK3 apps
+
+Message dialogs and windows with server-side decorations are deliberately left
+opaque: a translucent dialog is harder to read, and a translucent window under
+an opaque frame reads as a rendering bug.
+
+Any app that looks wrong can be added to Blur My Shell's per-app blacklist.
+
 ### The volume and brightness popup
 
 Stock GNOME shows a speaker icon, the output device's name and a bar every time
@@ -113,10 +172,16 @@ than reverting to upstream's.
 Upstream's last release targets GNOME 46 and its last commit does not run on
 50 at all — `ShellBlurEffect:sigma`, `meta_add_clutter_debug_flags()` and
 `OsdWindowManager.show()`'s signature have all changed since. `patches/custom-osd-gnome50.patch`
-fixes those and adds one thing upstream never had: a shader that clips the blur
-to the popup's corners. A background blur covers the actor's bounding box and
-knows nothing about `border-radius`, so without it a rounded pill sits inside a
-hard-edged rectangle of blur.
+fixes exactly those and nothing else.
+
+The blur behind the pill, and its rounded corners, come from Blur My Shell's
+popup component instead — `osd-window` is one of the surfaces it blurs. This
+project used to carry its own corner shader for that job, and it was the most
+fragile code here: a `Clutter.ShaderEffect` gets an offscreen buffer sized to
+the actor's *paint volume* rather than its allocation, which rendered a rounded
+pill on one GPU and a hard square on another. Blur My Shell's own corner effect
+clamps the radius instead, so the shape comes out right without this project
+maintaining a shader. The preset therefore ships `bg-effect='none'`.
 
 Pass `--no-osd` to leave the stock popup alone.
 
@@ -222,8 +287,8 @@ panel's geometry, which isn't settled at login — its own source notes that
 `get_transformed_position` "sometimes yields NaN when the actor is not fully
 positionned yet".
 
-Only seen on multi-monitor, so it is **off by default** — the fix costs a 12
-second wait after every login, which is not worth paying for a bug you probably
+Only seen on multi-monitor. The fix is **on by default** and costs a 12
+second wait after every login; pass `--no-panel-blur-fix` to skip it for a bug you probably
 don't have. If you do see the strip, run the installer with `--panel-blur-fix`
 to get `tahoe-glass-panel-blur.service`, which toggles the blur off and on once
 the session has settled and rebuilds the actor against correct geometry. If the
@@ -246,11 +311,10 @@ redistributable, and is not installed by this project — without it fontconfig
 substitutes your default sans, which is what the reference desktop does too.
 Change it in Open Bar's preferences if you want something deliberate.
 
-**There is no real blur behind popup menus.**
-There cannot be, from CSS. St — the GNOME Shell CSS engine — has no blur
-property at all, and Blur My Shell has no popup component. What you get instead
-is frosted translucency on a consistent material ladder. True backdrop blur
-behind menus needs a `Shell.BlurEffect` extension, which is a different project.
+**The popup blur shows the wallpaper, not the window behind it.**
+That is static blur, and it means `gnome-rounded-blur` is missing or has gone
+stale. See *Popup blur* above; `./install.sh --rounded-blur` fixes it. The
+installer says so on its own if it detects that case.
 
 ---
 
@@ -261,10 +325,10 @@ install.sh              entry point, flag parsing, step order
 lib/common.sh           output, prompting, pinned-clone and backup helpers
 lib/distro.sh           distro detection and dependency install per family
 lib/steps.sh            the steps themselves, with the upstream pins at the top
-css/                    the three CSS sheets
-dconf/core.ini          Open Bar + Blur My Shell + shell theme name
+css/                    the CSS sheets, some installed only when asked for
+dconf/core.ini          Open Bar + Blur My Shell + Custom OSD + shell theme name
 dconf/extras.ini        optional extensions
-patches/                Open Bar GNOME 50 patch
+patches/                the GNOME 50 patches for Open Bar and Custom OSD
 systemd/                the panel blur rebuild unit
 bin/tahoe-glass-apply   idempotent CSS re-apply
 ```
@@ -310,6 +374,7 @@ MIT, for the parts in this repository. The upstreams carry their own licences.
 
 [tahoe]: https://github.com/kayozxo/GNOME-macOS-Tahoe
 [bms]: https://github.com/aunetx/blur-my-shell
+[roundedblur]: https://github.com/kancko/gnome-rounded-blur
 [ob]: https://github.com/neuromorph/openbar
 [cosd]: https://github.com/neuromorph/custom-osd
 [ut]: https://extensions.gnome.org/extension/19/user-themes/

--- a/css/gtk4-transparency.css
+++ b/css/gtk4-transparency.css
@@ -1,0 +1,116 @@
+/* tahoe-glass — translucent app windows, so the blur behind them is visible.
+ *
+ * Appended after gtk4-tweaks.css, and only installed when --app-transparency
+ * asked for it.
+ *
+ * Blur My Shell's [applications] blur has never had anything to show through:
+ * libadwaita paints opaque grounds, so the blur sat behind a solid window and
+ * the only "transparency" available was opacity=240 on the window actor —
+ * which dims the text along with everything else. This makes the surfaces
+ * libadwaita actually paints translucent instead, so what you see behind a
+ * window is the blur rather than a dimmed copy of the window.
+ *
+ * Every rule is written twice, and the order is load-bearing.
+ * alpha(@window_bg_color, N) is the named-colour form: deprecated since
+ * libadwaita 1.6 and gone from the 1.9 docs, but still resolving through a
+ * back-compat shim. color-mix(in srgb, var(--window-bg-color) N%, transparent)
+ * is the form that survives that shim being removed. GTK drops a declaration
+ * it cannot parse and the last one it understands wins, so writing the old
+ * spelling first and the new one second means whichever GTK understands is
+ * the one that lands. Both are present in libadwaita 1.9.2.
+ *
+ * The percentages below are the shipped level, 0.92. --app-transparency N
+ * rewrites them in the installed copy, keeping the ladder between surfaces
+ * rather than flattening every one of them to the same number.
+ */
+
+/* ---------- The window itself ----------
+ * libadwaita paints .background rather than window on most widgets, but
+ * AdwWindow sets both and older dialogs only set window.
+ */
+window,
+window.background,
+.background,
+windowhandle {
+  background-color: alpha(@window_bg_color, 0.92);
+  background-color: color-mix(in srgb, var(--window-bg-color) 92%, transparent);
+}
+
+/* Server-side decorations paint an opaque frame around the window. Letting the
+ * window under it go translucent shows the frame through the content, which
+ * reads as a rendering bug rather than as glass.
+ */
+window.solid-csd,
+window.solid-csd .background {
+  background-color: @window_bg_color;
+  background-color: var(--window-bg-color);
+}
+
+/* ---------- Header bars and toolbars ---------- */
+headerbar,
+headerbar.titlebar,
+.titlebar,
+toolbarview > .toolbar,
+.toolbar,
+searchbar > revealer > box,
+actionbar > revealer > box {
+  background-color: alpha(@headerbar_bg_color, 0.88);
+  background-color: color-mix(in srgb, var(--headerbar-bg-color) 88%, transparent);
+}
+
+headerbar:backdrop,
+.titlebar:backdrop {
+  background-color: alpha(@headerbar_backdrop_color, 0.88);
+  background-color: color-mix(in srgb, var(--headerbar-backdrop-color) 88%, transparent);
+}
+
+/* ---------- Split-view panes ----------
+ * AdwNavigationSplitView and AdwOverlaySplitView paint their own opaque
+ * grounds. Without these the window is translucent everywhere except the
+ * sidebar, which looks worse than either extreme.
+ */
+.sidebar-pane,
+.navigation-sidebar,
+.sidebar-pane .navigation-sidebar,
+stacksidebar,
+placessidebar {
+  background-color: alpha(@sidebar_bg_color, 0.86);
+  background-color: color-mix(in srgb, var(--sidebar-bg-color) 86%, transparent);
+}
+
+.content-pane {
+  background-color: alpha(@window_bg_color, 0.92);
+  background-color: color-mix(in srgb, var(--window-bg-color) 92%, transparent);
+}
+
+/* ---------- Content views ----------
+ * .view is the ground under lists, grids and text. Left denser than the
+ * window on purpose: this is where text is actually read.
+ */
+.view,
+textview.view > text,
+columnview > listview,
+gridview,
+scrolledwindow > viewport > .view {
+  background-color: alpha(@view_bg_color, 0.94);
+  background-color: color-mix(in srgb, var(--view-bg-color) 94%, transparent);
+}
+
+/* ---------- Popovers ----------
+ * A popover has no wallpaper behind it, only the window it belongs to, so it
+ * needs just enough translucency to sit on the same material.
+ */
+popover > contents,
+popover > arrow {
+  background-color: alpha(@popover_bg_color, 0.94);
+  background-color: color-mix(in srgb, var(--popover-bg-color) 94%, transparent);
+}
+
+/* Message dialogs stay opaque. They exist to be read and answered, and a
+ * translucent one over a busy window is genuinely harder to read.
+ */
+window.dialog.message .dialog-vbox,
+window.messagedialog .background {
+  background-color: @dialog_bg_color;
+  background-color: var(--dialog-bg-color);
+}

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,7 @@ WANT_BMS_GIT=1
 WANT_POPUP_BLUR=1
 POPUP_BLUR_EXPLICIT=""
 WANT_ROUNDED_BLUR=1
+APP_TRANSPARENCY=""   # empty = remembered choice, then off
 CURSORS="adwaita"   # adwaita | mactahoe
 ICONS=""            # empty = remembered choice, then colloid
 GRAIN=""          # empty keeps the preset's value, or the remembered choice
@@ -72,6 +73,15 @@ ${C_BLD}tahoe-glass${C_OFF} — a macOS Tahoe glass desktop for GNOME 48-50
     --no-bms-git      use Blur My Shell's published build instead of the pinned
                       git one. That build has no popup component, so it
                       implies --no-popup-blur
+    --app-transparency N
+                      make app windows translucent so the blur behind them
+                      shows through, N from 0.70 to 1.00 (default 0.92). Off
+                      unless asked for, and not part of --full: apps that do
+                      not use GTK's stylesheet — Electron, Steam, anything
+                      drawing a video or GL surface — ignore it and stay
+                      opaque. Remembered for later runs
+    --no-app-transparency
+                      keep app windows opaque
     --no-rounded-blur skip gnome-rounded-blur. It is the only thing installed
                       outside \$HOME and it always asks first, --yes included.
                       Without it the popup blur is still rounded, it just
@@ -129,6 +139,9 @@ while [ $# -gt 0 ]; do
         --no-popup-blur) WANT_POPUP_BLUR=0; POPUP_BLUR_EXPLICIT=1; shift ;;
         --rounded-blur)      WANT_ROUNDED_BLUR=1; shift ;;
         --no-rounded-blur)   WANT_ROUNDED_BLUR=0; shift ;;
+        --app-transparency)  APP_TRANSPARENCY="${2:-0.92}"; shift 2 ;;
+        --app-transparency=*) APP_TRANSPARENCY="${1#*=}"; shift ;;
+        --no-app-transparency) APP_TRANSPARENCY=0; shift ;;
         --no-icons)      WANT_ICONS=0; shift ;;
         --no-cursors)    WANT_CURSORS=0; shift ;;
         --no-wm-buttons) WANT_WM_BUTTONS=0; shift ;;
@@ -153,6 +166,21 @@ if [ -z "$ICONS" ] && [ -r "$CONF_DIR/icon-pack" ]; then
     ICONS="$(cat "$CONF_DIR/icon-pack" 2>/dev/null || true)"
 fi
 ICONS="${ICONS:-colloid}"
+
+# Resolved here rather than inside the steps because two of them need it and
+# load_dconf runs before install_css. Same remembered-choice rule as --icons.
+if [ -z "$APP_TRANSPARENCY" ] && [ -r "$CONF_DIR/app-transparency" ]; then
+    APP_TRANSPARENCY="$(cat "$CONF_DIR/app-transparency" 2>/dev/null || true)"
+fi
+APP_TRANSPARENCY="${APP_TRANSPARENCY:-0}"
+case "$APP_TRANSPARENCY" in
+    0|0.0) APP_TRANSPARENCY=0 ;;
+    *)
+        # Below 0.70 the text starts riding the wallpaper rather than a
+        # surface, and 1.00 is just "off" spelled the long way.
+        awk -v v="$APP_TRANSPARENCY" 'BEGIN{exit !(v+0>=0.70 && v+0<=1.00 && v ~ /^[0-9.]+$/)}' \
+            || die "--app-transparency takes 0, or a number from 0.70 to 1.00 — got '$APP_TRANSPARENCY'" ;;
+esac
 
 VALID_REVERSAL="default black blue brown cyan green grey lightblue orange pink purple red"
 case "$ICONS" in

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -63,6 +63,23 @@ confirm_always() {
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
+# patch_stamp NAME PATCHFILE — true when the installed build already came from
+# this exact patch. A patched extension is built once and then skipped forever
+# on the strength of the directory existing, so editing a patch used to change
+# nothing on a machine that had already installed: the old build stayed, and
+# the only symptom was code on disk that no longer matched the repo.
+patch_stamp_current() {
+    local name="$1" patch="$2"
+    [ -r "$CONF_DIR/$name" ] || return 1
+    [ "$(cat "$CONF_DIR/$name" 2>/dev/null)" = "$(sha256sum "$patch" | cut -d' ' -f1)" ]
+}
+patch_stamp_write() {
+    local name="$1" patch="$2"
+    [ "${DRY_RUN:-0}" = 1 ] && return 0
+    mkdir -p "$CONF_DIR"
+    sha256sum "$patch" | cut -d' ' -f1 > "$CONF_DIR/$name"
+}
+
 # Clone at a pinned ref, or fetch that ref into an existing clone. Pinning
 # matters here: both upstreams are moving targets, and a theme that changes
 # under the tweaks is how you end up with half-applied CSS.

--- a/lib/steps.sh
+++ b/lib/steps.sh
@@ -325,7 +325,9 @@ install_openbar() {
         return
     fi
 
-    if [ -d "$EXT_DIR/$uuid" ] && ext_supports_shell "$EXT_DIR/$uuid" "$GNOME_MAJOR" && [ "${FORCE:-0}" != 1 ]; then
+    if [ -d "$EXT_DIR/$uuid" ] && ext_supports_shell "$EXT_DIR/$uuid" "$GNOME_MAJOR" \
+       && patch_stamp_current openbar-patch "$REPO_ROOT/patches/openbar-gnome50.patch" \
+       && [ "${FORCE:-0}" != 1 ]; then
         skip "$uuid already patched for GNOME $GNOME_MAJOR"
         return 0
     fi
@@ -350,6 +352,7 @@ install_openbar() {
         glib-compile-schemas "$EXT_DIR/$uuid/schemas" \
             || die "failed to compile Open Bar's gsettings schemas"
     fi
+    patch_stamp_write openbar-patch "$REPO_ROOT/patches/openbar-gnome50.patch"
     ok "$uuid (patched for GNOME $GNOME_MAJOR)"
 }
 
@@ -369,6 +372,7 @@ install_custom_osd() {
     fi
 
     if [ -d "$EXT_DIR/$uuid" ] && ext_supports_shell "$EXT_DIR/$uuid" "$GNOME_MAJOR" \
+       && patch_stamp_current custom-osd-patch "$REPO_ROOT/patches/custom-osd-gnome50.patch" \
        && [ "${FORCE:-0}" != 1 ]; then
         skip "$uuid already patched for GNOME $GNOME_MAJOR"
         return 0
@@ -401,6 +405,7 @@ install_custom_osd() {
 
     glib-compile-schemas "$EXT_DIR/$uuid/schemas" \
         || die "failed to compile Custom OSD's gsettings schemas"
+    patch_stamp_write custom-osd-patch "$REPO_ROOT/patches/custom-osd-gnome50.patch"
     ok "$uuid (patched for GNOME $GNOME_MAJOR)"
 }
 

--- a/lib/steps.sh
+++ b/lib/steps.sh
@@ -790,6 +790,52 @@ print(f"""
 PY
 }
 
+# css/gtk4-transparency.css is written at the shipped level (0.92) so that the
+# file is readable on its own. --app-transparency N rewrites both spellings of
+# every value in the installed copy, scaling the whole ladder rather than
+# flattening it: the header bar is meant to stay a little more transparent than
+# the window and the content view a little less, at any setting.
+install_transparency_css() {
+    local level="${APP_TRANSPARENCY:-0}"
+
+    if [ "$level" = 0 ]; then
+        run rm -f "$CONF_DIR/gtk4-transparency.css"
+        [ "${DRY_RUN:-0}" = 1 ] || { mkdir -p "$CONF_DIR"; printf '0\n' > "$CONF_DIR/app-transparency"; }
+        return 0
+    fi
+
+    run install -Dm644 "$REPO_ROOT/css/gtk4-transparency.css" "$CONF_DIR/gtk4-transparency.css"
+
+    if [ "${DRY_RUN:-0}" = 1 ]; then
+        info "dry-run: rewrite the transparency sheet to $level"
+        return 0
+    fi
+
+    python3 - "$CONF_DIR/gtk4-transparency.css" "$level" <<'PY'
+import re, sys
+path, want = sys.argv[1], float(sys.argv[2])
+SHIPPED = 0.92
+
+def scale(base):
+    # Keep each surface's distance from opaque in proportion, so the ladder
+    # written into the sheet survives being retuned.
+    if want >= 1.0:
+        return 1.0
+    return max(0.0, min(1.0, 1 - (1 - base) * (1 - want) / (1 - SHIPPED)))
+
+css = open(path, encoding="utf-8").read()
+css = re.sub(r"alpha\((@[a-z_]+), ([0-9.]+)\)",
+             lambda m: "alpha(%s, %.2f)" % (m.group(1), scale(float(m.group(2)))), css)
+css = re.sub(r"(var\(--[a-z-]+\)) ([0-9.]+)%",
+             lambda m: "%s %g%%" % (m.group(1), round(scale(float(m.group(2)) / 100) * 100, 1)), css)
+open(path, "w", encoding="utf-8").write(css)
+PY
+
+    mkdir -p "$CONF_DIR"
+    printf '%s\n' "$level" > "$CONF_DIR/app-transparency"
+    ok "app windows translucent at $level (remembered for later runs)"
+}
+
 install_css() {
     step "Installing the CSS tweaks"
 
@@ -806,6 +852,7 @@ install_css() {
     else
         run rm -f "$CONF_DIR/shell-popup-blur.css"
     fi
+    install_transparency_css
     ok "css -> $CONF_DIR"
     ok "re-apply command -> ~/.local/bin/tahoe-glass-apply"
 
@@ -861,7 +908,18 @@ load_dconf() {
 
     apply_grain
     apply_popup_blur
+    apply_app_opacity
     sync_osd_profile
+}
+
+# [applications] opacity dims the whole window actor, text included. That is
+# the only transparency available while GTK paints an opaque background, but
+# once GTK is doing it properly the two multiply and the text goes muddy — so
+# the actor goes back to fully opaque and the stylesheet does the work alone.
+apply_app_opacity() {
+    [ "${APP_TRANSPARENCY:-0}" != 0 ] || return 0
+    run dconf write /org/gnome/shell/extensions/blur-my-shell/applications/opacity 255
+    ok "window actor opacity back to 255 — GTK is doing the transparency now"
 }
 
 # The popup keys themselves ship in dconf/core.ini so the whole preset stays

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -198,7 +198,8 @@ run rm -f "$HOME/.local/bin/tahoe-glass-apply" "$HOME/.local/bin/tahoe-glass-ico
 run rm -f "$CONF_DIR/bms-ref" "$CONF_DIR/bms-source" \
           "$CONF_DIR/shell-popup-blur.css" "$CONF_DIR/popup-blur" \
           "$CONF_DIR/rounded-blur" \
-          "$CONF_DIR/gtk4-transparency.css" "$CONF_DIR/app-transparency"
+          "$CONF_DIR/gtk4-transparency.css" "$CONF_DIR/app-transparency" \
+          "$CONF_DIR/openbar-patch" "$CONF_DIR/custom-osd-patch"
 if confirm "Delete $CONF_DIR (this also deletes the backups above)?" 0; then
     run rm -rf "$CONF_DIR"
     ok "removed"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -197,7 +197,8 @@ run rm -f "$HOME/.local/bin/tahoe-glass-apply" "$HOME/.local/bin/tahoe-glass-ico
 # the user made — so they go now instead of waiting on the $CONF_DIR prompt.
 run rm -f "$CONF_DIR/bms-ref" "$CONF_DIR/bms-source" \
           "$CONF_DIR/shell-popup-blur.css" "$CONF_DIR/popup-blur" \
-          "$CONF_DIR/rounded-blur"
+          "$CONF_DIR/rounded-blur" \
+          "$CONF_DIR/gtk4-transparency.css" "$CONF_DIR/app-transparency"
 if confirm "Delete $CONF_DIR (this also deletes the backups above)?" 0; then
     run rm -rf "$CONF_DIR"
     ok "removed"


### PR DESCRIPTION
Stacked on the popup-blur PR.

Blur My Shell's `[applications]` blur has never had anything to show through: libadwaita paints opaque grounds, so the blur sat behind a solid window and the only transparency available was `opacity=240` on the window actor — which dims text along with everything else.

`window {}` alone is not enough: `.background`, `headerbar`, the split-view panes, `.view` and popovers all paint their own grounds. Kept deliberately opaque: `window.solid-csd` (a translucent window under an opaque server-side frame reads as a rendering bug) and message dialogs (they exist to be read).

Every rule is written twice, old spelling first — `alpha(@window_bg_color, N)` then `color-mix(in srgb, var(--window-bg-color) N%, transparent)`. GTK drops what it cannot parse and the last understood declaration wins. Both spellings are present in libadwaita 1.9.2.

**Off by default and not in `--full`**, unlike everything else there: Electron, Steam, Java and anything drawing a GL or video surface ignore GTK's stylesheet, so `--full` would promise a coherent desktop and deliver an uneven one.

## Verified
- GTK 4.22.4 parses both sheets with **0** errors via `Gtk.CssProvider`
- the level rescaler preserves the ladder: at `0.80`, window `0.80` / headerbar `0.70` / sidebar `0.65` / view `0.85`
- validation rejects `0.5`, `1.5`, `abc`; accepts `0`, `0.70`, `0.92`, `1.00`

## Honest gap
In the headless session the effect is **measurable but partial** — ~47k pixels change and the header bar clearly lightens, but the sidebar and file grid stayed opaque. That may be a selector gap or an artifact of the test (no theme installed there, `opacity` still 240). Wants a real session before this is called done. It is opt-in and isolated on this branch, so it blocks nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)